### PR TITLE
Update gcloudsdk checksum

### DIFF
--- a/gcloudsdk/gcloudsdk.nuspec
+++ b/gcloudsdk/gcloudsdk.nuspec
@@ -5,7 +5,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gcloudsdk</id>
-    <version>0.0.0.20190318</version>
+    <!-- Use the signing time of the executable file as the version. -->
+    <version>0.0.0.20200527</version>
     <packageSourceUrl>https://github.com/gpoul/chocolatey-packages</packageSourceUrl>
     <owners>gpoul</owners>
     <title>Google Cloud SDK (Install)</title>

--- a/gcloudsdk/tools/chocolateyinstall.ps1
+++ b/gcloudsdk/tools/chocolateyinstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
 
   softwareName  = 'gcloudsdk*'
 
-  checksum      = '987B4D4DDCCDD169055D7547D089B09C52C39DF10FB752CF626360480C5F3C51'
+  checksum      = 'B01C0451E9BDDAC5563D4D7B65466372883A4197D2B79EA98377E7BDCC1DF936'
   checksumType  = 'sha256'
 
   silentArgs    = "/S /allusers"


### PR DESCRIPTION
Use the signing time of the executable file as the version instead of using the last modified date in HTTP header, because the signing time is easier to obtain.